### PR TITLE
fix: sometimes the State is turning to initial before routing to the …

### DIFF
--- a/app/allocation/[category]/page.tsx
+++ b/app/allocation/[category]/page.tsx
@@ -338,6 +338,7 @@ const RankingPage = () => {
   const handleAttestationModalClose = () => {
     if (attestationState === AttestationState.Success || attestationState == AttestationState.FarcasterDelegate) {
       router.push('/allocation');
+      setAttestationState(AttestationState.Initial);
     }
     else if (attestationState === AttestationState.Error) {
       setAttestationState(AttestationState.Initial);
@@ -433,7 +434,6 @@ const RankingPage = () => {
               }
               else {
                 handleAttestationModalClose();
-                setAttestationState(AttestationState.Initial);
               }
             }}
             isBadgeHolder={isBadgeholder}
@@ -443,7 +443,6 @@ const RankingPage = () => {
           <AttestationSuccessModal
             link={attestationLink}
             onClose={() => {
-              setAttestationState(AttestationState.Initial);
               handleAttestationModalClose();
             }}
           />


### PR DESCRIPTION
relates to: 
by tapping on close in budget allocation page the user isn't redirected to allocation page

but in category page by tapping on this button user is redirected to allocation page