### PR TITLE
Disallow negative values in voting and allocation buttons

### DIFF
--- a/app/allocation/[category]/components/RankingRow.tsx
+++ b/app/allocation/[category]/components/RankingRow.tsx
@@ -98,7 +98,7 @@ const RankingRow: FC<IRankingRowProps> = ({
                 className={`font-bold ${
                   coi ? 'text-dark-500/[.2]' : 'text-gray-600'
                 }`}
-                disabled={locked || coi}
+                disabled={locked || coi || project.share === 0}
               >
                 -
               </button>
@@ -122,13 +122,14 @@ const RankingRow: FC<IRankingRowProps> = ({
                 placeholder="0.00%"
                 isAllowed={values => handleAllowdValue(values)}
                 disabled={locked || coi}
+                allowNegative={false}
               />
               <button
                 onClick={() => onVote(project.projectId, project.share + 0.01)}
                 className={`font-bold ${
                   coi ? 'text-dark-500/[.2]' : 'text-gray-600'
                 }`}
-                disabled={locked || coi}
+                disabled={locked || coi || project.share >= 1}
               >
                 +
               </button>

--- a/app/allocation/[category]/components/UpdateBallotButton.tsx
+++ b/app/allocation/[category]/components/UpdateBallotButton.tsx
@@ -99,7 +99,7 @@ export const UpdateBallotButton: FC<IProps> = ({ isBadgeHolderAndNotVoted = fals
         )}
       </Modal>
       <button
-        className={`flex h-fit w-fit flex-row items-center justify-center gap-2.5 self-end rounded-lg px-4 py-3 ${
+        className={`flex size-fit flex-row items-center justify-center gap-2.5 self-end rounded-lg px-4 py-3 ${
           ballotState === BallotState.Loading
           || (isBadgeHolderAndNotVoted)
             ? 'bg-gray-300 text-gray-500'

--- a/app/allocation/components/CategoryAllocation.tsx
+++ b/app/allocation/components/CategoryAllocation.tsx
@@ -159,6 +159,7 @@ const CategoryAllocation: FC<CategoryAllocationProps> = ({
                       <button
                         onClick={handleMinus}
                         className="font-bold text-gray-600"
+                        disabled={allocationPercentage === 0}
                       >
                         -
                       </button>


### PR DESCRIPTION
Implement checks to prevent negative values in project shares and allocation percentages, enhancing input validation across the application.